### PR TITLE
Adding an International section to the list 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Name | Architecture | Details
 -----|--------------|--------
 TCN | Decentralized | https://github.com/ct-report/TCN
 MIT PrivateKit | Decentralized | https://github.com/ct-report/MIT
-OpenTrace | Centralized | https://github.com/ct-report/OPENTRACE
+OpenTrace (from Singapore see below) | Centralized | https://github.com/ct-report/OPENTRACE
 
 - International
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ TCN | Decentralized | https://github.com/ct-report/TCN
 MIT PrivateKit | Decentralized | https://github.com/ct-report/MIT
 OpenTrace | Centralized | https://github.com/ct-report/OPENTRACE
 
+- International
+
+Country | Status | App Details | License | Protocol
+--------|--------|-------------|---------|---------
+Australia | Government Official (CovidSafe) | https://github.com/AU-COVIDSafe/mobile-android | | BlueTrace.io
+Singapore | Government Official (TraceTogether) | https://github.com/opentrace-community | GPLv3 | BlueTrace.io
+India | Government Official (Aarogya Setu) | https://github.com/nic-delhi/AarogyaSetu_Android | Apache 2.0 |
+
 - Apple+Google Exposure Notifications API
 
 Name | Details


### PR DESCRIPTION
Hi. I've added a new section on International efforts which includes Singapore, Australia and India. I've also clarified in the Other Framework section's entry "OPENTRACE" to indicate that it is from Singapore as well.

Thanks for setting up this repo Very useful.

Harish